### PR TITLE
Update pip install command for Apache Toree

### DIFF
--- a/site/docs/current/user/installation.md
+++ b/site/docs/current/user/installation.md
@@ -38,7 +38,7 @@ An Apache Spark distribution is required to be installed before installing Apach
 The quickest way to install Apache Toree is through the toree pip package.
 
 ```
-pip install toree
+pip install apache-toree
 ```
 
 This will install a jupyter application called `toree`, which can be used to install and configure different Apache Toree kernels.

--- a/site/docs/current/user/quick-start.md
+++ b/site/docs/current/user/quick-start.md
@@ -41,7 +41,7 @@ This requires you to have a distribution of [Apache Spark][1] downloaded to the 
 following commands will install Apache Toree.
 
 ```
-pip install --upgrade toree
+pip install --upgrade apache-toree
 jupyter toree install --spark_home=/usr/local/bin/apache-spark/
 ```
 

--- a/site/download.md
+++ b/site/download.md
@@ -72,7 +72,7 @@ limitations under the License.
 You can also install Apache Toree directly from PyPI:
 
 <pre>
-pip install --upgrade toree
+pip install --upgrade apache-toree
 </pre>
 
 ### Previous Releases


### PR DESCRIPTION
https://pypi.org/project/apache-toree/ exists so we should prefer that.

See https://incubator.apache.org/guides/distribution.html#pypi for why we should not be using the non apache prefixed version.